### PR TITLE
feat: Add SheetScorer tool for analyzing Jewish study sheets with LLM…

### DIFF
--- a/app/celery_setup/app.py
+++ b/app/celery_setup/app.py
@@ -3,4 +3,4 @@ from celery_setup.config import generate_config_from_env
 
 app = Celery('llm')
 app.conf.update(**generate_config_from_env())
-app.autodiscover_tasks(packages=['topic_prompt'])
+app.autodiscover_tasks(packages=['topic_prompt', 'sheet_scoring'])

--- a/app/llm_interface/sefaria_llm_interface/scoring_io/__init__.py
+++ b/app/llm_interface/sefaria_llm_interface/scoring_io/__init__.py
@@ -1,0 +1,4 @@
+from .scoring_io_input import SheetScoringInput
+from .scoring_io_output import SheetScoringOutput
+
+__all__ = ["SheetScoringInput", "SheetScoringOutput"]

--- a/app/llm_interface/sefaria_llm_interface/scoring_io/scoring_io_input.py
+++ b/app/llm_interface/sefaria_llm_interface/scoring_io/scoring_io_input.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
 from typing import Any
+
+
 @dataclass
 class SheetScoringInput:
     sheet_content: dict[str, Any]

--- a/app/llm_interface/sefaria_llm_interface/scoring_io/scoring_io_input.py
+++ b/app/llm_interface/sefaria_llm_interface/scoring_io/scoring_io_input.py
@@ -1,0 +1,6 @@
+from dataclasses import dataclass
+from typing import Any
+@dataclass
+class SheetScoringInput:
+    sheet_content: dict[str, Any]
+

--- a/app/llm_interface/sefaria_llm_interface/scoring_io/scoring_io_output.py
+++ b/app/llm_interface/sefaria_llm_interface/scoring_io/scoring_io_output.py
@@ -1,0 +1,36 @@
+from dataclasses import dataclass
+from typing import Dict, Union, List
+from datetime import datetime
+
+
+@dataclass
+class SheetScoringOutput:
+    sheet_id:str
+    processed_at: str
+    language: str
+    title_interest_level: int
+    title_interest_reason: str
+    creativity_score:float
+    ref_levels: Dict[str, int]
+    ref_scores: Dict[str, float]
+
+
+    def __init__(self,
+                 sheet_id: str,
+                 ref_scores: Dict[str, float],
+                 ref_levels:Dict[str, int],
+                 processed_at: Union[str, datetime],
+                 language: str,
+                 creativity_score: float,
+                 title_interest_level: int,
+                 title_interest_reason: str):
+        self.ref_scores = ref_scores
+        self.sheet_id = sheet_id
+        self.processed_at = processed_at.isoformat() if isinstance(
+            processed_at, datetime
+        ) else processed_at
+        self.ref_levels = ref_levels
+        self.creativity_score = creativity_score
+        self.language = language
+        self.title_interest_level = title_interest_level
+        self.title_interest_reason = title_interest_reason

--- a/app/llm_interface/sefaria_llm_interface/scoring_io/scoring_io_output.py
+++ b/app/llm_interface/sefaria_llm_interface/scoring_io/scoring_io_output.py
@@ -1,36 +1,19 @@
 from dataclasses import dataclass
-from typing import Dict, Union, List
+from typing import Dict, Union
 from datetime import datetime
 
 
 @dataclass
 class SheetScoringOutput:
-    sheet_id:str
-    processed_at: str
+    sheet_id: str
+    processed_datetime: str
     language: str
     title_interest_level: int
     title_interest_reason: str
-    creativity_score:float
+    creativity_score: float
     ref_levels: Dict[str, int]
     ref_scores: Dict[str, float]
 
-
-    def __init__(self,
-                 sheet_id: str,
-                 ref_scores: Dict[str, float],
-                 ref_levels:Dict[str, int],
-                 processed_at: Union[str, datetime],
-                 language: str,
-                 creativity_score: float,
-                 title_interest_level: int,
-                 title_interest_reason: str):
-        self.ref_scores = ref_scores
-        self.sheet_id = sheet_id
-        self.processed_at = processed_at.isoformat() if isinstance(
-            processed_at, datetime
-        ) else processed_at
-        self.ref_levels = ref_levels
-        self.creativity_score = creativity_score
-        self.language = language
-        self.title_interest_level = title_interest_level
-        self.title_interest_reason = title_interest_reason
+    def __post_init__(self):
+        if isinstance(self.processed_datetime, datetime):
+            self.processed_datetime = self.processed_datetime.isoformat()

--- a/app/sheet_scoring/README.md
+++ b/app/sheet_scoring/README.md
@@ -1,0 +1,227 @@
+# SheetScorer - Jewish Study Sheet Analysis Tool
+
+**SheetScorer** is a Python tool that uses **LLMs** to automatically analyze and score Jewish study sheets for reference relevance and title interest. It processes sheets from **MongoDB**, evaluates how well biblical references are discussed, and assigns engagement scores to sheet titles.
+
+## Scores Extracted
+
+- **Reference Discussion Scoring**: Analyzes how thoroughly each biblical reference is discussed (**0-4 scale**)
+- **Title Interest Scoring**: Evaluates how engaging sheet titles are to potential readers (**0-4 scale**)  
+- **Creativity Assessment**: Computes creativity scores based on percentage of **user-generated content**
+- **Title Interest Reason**: Explanation of title scoring. 
+
+## Quick Start
+
+```python
+from sheet_scorer import SheetScorer
+
+# Initialize scorer
+scorer = SheetScorer(
+    api_key="your-openai-api-key",
+    model="gpt-4o-mini"
+)
+
+# Process a sheet
+sheet_data = {
+    "_id": "sheet123",
+    "title": "Understanding Genesis Creation",
+    "expandedRefs": ["Genesis 1:1", "Genesis 1:2", "Genesis 1:3"],
+    # ... other sheet content
+}
+
+result = scorer.process_sheet_by_content(sheet_data)
+print(result)
+```
+
+## Scoring System
+
+### Reference Discussion Levels
+
+The tool evaluates how well each biblical reference is discussed using a **0-4 scale**:
+
+| Level | Description |
+|-------|-------------|
+| **0 - Not Discussed** | Reference is **quoted only**, no discussion or commentary |
+| **1 - Minimal** | Mentioned only through **neighboring verses**, minimal engagement |
+| **2 - Moderate** | Some discussion present with **basic commentary** |
+| **3 - Significant** | **Substantial discussion** with detailed commentary |
+| **4 - Central** | Reference is a **central focus** of the entire sheet |
+
+### Title Interest Levels
+
+Sheet titles are scored for **user engagement** on a **0-4 scale**:
+
+| Level | Description |
+|-------|-------------|
+| **0 - Not Interesting** | **Off-topic** or unengaging for target users |
+| **1 - Slight Relevance** | **Low appeal**, users unlikely to engage |
+| **2 - Somewhat Interesting** | Users might **skim**, moderate appeal |
+| **3 - Interesting** | Users **likely to open** and read |
+| **4 - Very Compelling** | **Must-read content**, high engagement expected |
+
+### Creativity Score
+
+Calculated as the **percentage of user-generated content** versus all text (including quoted canonical text). Higher scores indicate more **original commentary** and analysis.
+
+## Configuration Options
+
+### Initialization Parameters
+
+```python
+scorer = SheetScorer(
+    api_key="your-api-key",           # OpenAI API key
+    model="gpt-4o-mini",              # Model to use
+    max_prompt_tokens=128000,         # Maximum input tokens
+    token_margin=16384,               # Reserved tokens for output
+    max_ref_to_process=800,           # Maximum references to process
+    chunk_size=80                     # References per chunk
+)
+```
+
+### Key Constants
+
+- **DEFAULT_MAX_OUTPUT_TOKENS**: **16384**
+- **DEFAULT_CHUNK_SIZE**: **80** references per processing chunk
+- **DEFAULT_MAX_INPUT_OUTPUT_TOKENS**: **128000** total token limit
+- **MAX_CHUNK_OVERLAP**: **10** references overlap between chunks
+
+## Core Methods
+
+### **process_sheet_by_content(sheet, add_full_comment)**
+
+**Main method** to process a complete sheet and return scores.
+
+**Parameters:**
+- `sheet` (**Dict**): **MongoDB** sheet document containing title, references, and content
+- `add_full_comment` (**bool**): parameter that allows to add quotations text to input that LLM receives
+
+**Returns:**
+- **Dictionary** with scoring results or **None** if processing fails
+
+**Example Output:**
+```python
+{
+    "_id": "sheet123",
+    "ref_levels": {"Genesis 1:1": 3, "Genesis 1:2": 2},
+    "ref_scores": {"Genesis 1:1": 60.0, "Genesis 1:2": 40.0},
+    "title_interest_level": 3,
+    "title_interest_reason": "Compelling theological question",
+    "language": "en",
+    "creativity_score": 0.75,
+    "processed_at": "2025-01-31T10:30:00Z"
+}
+```
+! ref_scores is normalized version of ref_levels
+
+### **get_gpt_scores(content, ref_names, title)**
+
+**Core scoring method** that processes content and returns analysis.
+
+**Parameters:**
+- `content` (**str**): Sheet text content to analyze
+- `ref_names` (**List[str]**): List of biblical references to score
+- `title` (**str**): Sheet title to evaluate
+
+## Content Processing Strategy
+
+The tool uses an **adjustable approach** for canonical quotations:
+
+1. **Always includes** all user commentary and **original content**
+2. **Conditionally includes** canonical quotes only if the **entire bundle** fits within token limits
+and **add_full_comment is set to True** 
+3. **Truncates intelligently** using **LLM summarization** when content exceeds limits 
+   4. ***LLM Summarization***: Uses secondary LLM to compress content while preserving key information 
+   5. ***Reference Preservation***: Maintains all biblical reference tags during compression 
+   6. ***Character Fallback***: Falls back to character-based truncation if summarization fails
+
+## Grading Strategy 
+Processed content is sent to LLM, together with references for grading: 
+
+### Resilient Grading List Processing
+
+- **Chunking**: Large reference lists are processed in **chunks** to stay within model limits
+- **Overlap Handling**: Smart overlap between chunks prevents **reference boundary issues**
+
+### Resilient Reference Grading
+
+- **Primary attempt**: Process **all references together**
+- **Fallback**: Split reference list in **half** and process **recursively**
+- **Final fallback**: Assign **default score of 0** to problematic references
+
+
+### Resilient score extraction 
+
+Uses **OpenAI's function calling** feature with **strict schemas**:
+
+#### Middle Chunk Scoring Schema 
+```python
+{
+    "name": "score_references",
+    "parameters": {
+        "ref_levels": {
+            "Genesis 1:1": {"type": "integer", "minimum": 0, "maximum": 4},
+            # ... for each reference
+        }
+    }
+}
+```
+
+#### Title Scoring Schema
+```python
+{
+    "name": "score_title", 
+    "parameters": {
+        "language": {"type": "string"},
+        "title_interest_level": {"type": "integer", "minimum": 0, "maximum": 4},
+        "title_interest_reason": {"type": "string", "maxLength": 100}
+    }
+}
+```
+
+
+## Database Integration
+
+Designed for **MongoDB integration** with expected document structure:
+
+```python
+{
+    "_id": "unique_sheet_id",
+    "title": "Sheet Title",
+    "expandedRefs": ["Genesis 1:1", "Exodus 2:3"],
+    # Additional sheet content fields...
+}
+```
+
+## Output Fields
+
+| Field | Description |
+|-------|-------------|
+| **`ref_levels`** | Raw **0-4 scores** for each reference |
+| **`ref_scores`** | **Normalized percentage scores** (sum to 100%) |
+| **`title_interest_level`** | Title **engagement score** (0-4) |
+| **`title_interest_reason`** | **Brief explanation** of title score |
+| **`language`** | **Detected language code** |
+| **`creativity_score`** | **Percentage** of user-generated content |
+| **`processed_at`** | **Processing timestamp** |
+
+## Logging
+
+**Comprehensive logging** for monitoring and debugging:
+
+- **Info**: Processing decisions and **content statistics**
+- **Warning**: **Score validation** and fallback usage  
+- **Error**: **LLM failures** and processing errors
+
+Configure logging level as needed:
+```python
+import logging
+logging.getLogger('sheet_scorer').setLevel(logging.INFO)
+```
+
+
+## Language Support
+
+Supports **automatic detection** and processing of:
+
+- **English** (`en`) - **Default language**
+- **Hebrew** (`he`) - Full **RTL support**
+- Language detection based on **original user-written content**

--- a/app/sheet_scoring/openai_sheets_scorer.py
+++ b/app/sheet_scoring/openai_sheets_scorer.py
@@ -2,13 +2,12 @@ import json
 import logging
 from datetime import datetime
 from enum import IntEnum
-from typing import Any,Dict,Iterator,List,Optional,Set,Tuple
-
+from typing import Any, Dict, Iterator, List, Optional, Set, Tuple
+import textwrap
 import tiktoken
 from langchain.schema import HumanMessage
 from langchain_openai import ChatOpenAI
-
-from app.sheet_scoring.text_utils import sheet_to_text_views
+from sheet_scoring.text_utils import sheet_to_text_views
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -41,11 +40,30 @@ class SheetScorer:
     computes creativity score based on percentage of user generated content.
 
     This class processes sheets from MongoDB, analyzes their content using OpenAI's GPT models,
-    and assigns scores for how well each biblical reference is discussed and how interesting
+    and assigns scores for how well each reference is discussed and how interesting
     the sheet title is to users.
     """
 
-    # Configuration constants
+    # Configuration constants -
+    # DEFAULT_MAX_INPUT_OUTPUT_TOKENS: total
+    # tokens (prompt+response) we’ll send in one API call. Lowering this
+    # shrinks your available context; raising it risks exceeding the model’s
+    # limit.
+    # DEFAULT_MAX_OUTPUT_TOKENS: cap on how many tokens the model
+    # may generate. If you set this too low, responses may be cut off; too
+    # high wastes quota.
+    # DEFAULT_CHUNK_SIZE: how many references to score
+    # in each batch. Larger chunks use more context (better global view) but
+    # may exceed token budgets.
+    # MAX_CHUNK_OVERLAP: how many refs to repeat
+    # between chunks. More overlap reduces missing-edge-case errors at the
+    # cost of redundant API calls.
+    # DEFAULT_MAX_REFS_TO_PROCESS: total refs
+    # before falling back to equal-distribution scoring. Hitting this limit
+    # skips heavy LLM work to avoid runaway costs. -
+    # DEFAULT_TOKEN_CHAR_RATIO: fallback characters‐per‐token estimate when
+    # encoding fails. Tweak if you find your actual token counts diverge
+    # significantly from this estimate.
     DEFAULT_MAX_OUTPUT_TOKENS = 16384
     DEFAULT_CHUNK_SIZE = 80
     DEFAULT_MAX_INPUT_OUTPUT_TOKENS = 128000
@@ -59,7 +77,7 @@ class SheetScorer:
     LANGUAGE_FIELD = "language"
     TITLE_INTEREST_REASON_FIELD = 'title_interest_reason'
     SHEET_ID_FIELD = "_id"
-    PROCESSED_AT_FIELD = "processed_at"
+    PROCESSED_AT_FIELD = "processed_datetime"
     CREATIVITY_SCORE_FIELD = 'creativity_score'
 
     # Valid score levels
@@ -83,7 +101,7 @@ class SheetScorer:
         self.llm = self._create_json_llm(api_key,model)
         self.summarizer = self._create_text_llm(api_key,model)
 
-    def _create_json_llm(self,api_key: str,model: str) -> ChatOpenAI:
+    def _create_json_llm(self, api_key: str, model: str) -> ChatOpenAI:
         """Create LLM client for JSON responses."""
         return ChatOpenAI(
             model=model,
@@ -95,7 +113,7 @@ class SheetScorer:
             api_key=api_key,
         )
 
-    def _create_text_llm(self,api_key: str,model: str) -> ChatOpenAI:
+    def _create_text_llm(self, api_key: str, model: str) -> ChatOpenAI:
         """Create LLM client for text responses."""
         return ChatOpenAI(
             model=model,
@@ -104,9 +122,9 @@ class SheetScorer:
             api_key=api_key,
         )
 
-    def _invoke_llm_with_function(self,prompt: str,
-                                  function_schema: Dict[str,Any]) -> Dict[
-        str,Any]:
+    def _invoke_llm_with_function(self, prompt: str,
+                                  function_schema: Dict[str, Any]) -> (
+            Dict)[str, Any]:
         """Invoke LLM using function calling instead of JSON mode."""
         response = self.llm.invoke(
             [HumanMessage(content=prompt)],
@@ -114,21 +132,22 @@ class SheetScorer:
             function_call={"name": function_schema["name"]}
         )
 
-        # Extract function call arguments
-        if hasattr(
-                response,'additional_kwargs'
-        ) and 'function_call' in response.additional_kwargs:
-            function_call = response.additional_kwargs['function_call']
-            return json.loads(function_call['arguments'])
-        else:
-            raise ValueError("No function call in response")
+        function_call = getattr(response, "additional_kwargs", {}).get(
+            "function_call"
+            )
+        if function_call:
+            return json.loads(function_call["arguments"])
 
-    def _get_reference_scoring_function_schema(self,ref_names: List[str]) -> \
-            Dict[str,Any]:
-        """Create function schema for reference scoring with exact reference names."""
+        raise ValueError("No function call in response")
+
+    def _get_reference_scoring_function_schema(self, ref_names: List[str]) -> \
+            Dict[str, Any]:
+        """Create function schema for reference scoring with exact reference
+        names."""
         return {
             "name": "score_references",
-            "description": "Score how well each biblical reference is discussed in the sheet",
+            "description": "Score how well each reference is "
+                           "discussed in the sheet",
             "parameters": {
                 "type": "object",
                 "properties": {
@@ -153,8 +172,7 @@ class SheetScorer:
             }
         }
 
-    def _get_title_scoring_schema(self) -> Dict[
-        str,Any]:
+    def _get_title_scoring_schema(self) -> Dict[str, Any]:
         """Create function schema for both reference and title scoring."""
         return {
             "name": "score_title",
@@ -168,34 +186,38 @@ class SheetScorer:
                     },
                     self.TITLE_INTEREST_FIELD: {
                         "type": "integer",
-                        "description": "How interesting the title is to users (0-4 scale)",
+                        "description": "How interesting the title is to "
+                                       "users (0-4 scale)",
                         "minimum": 0,
                         "maximum": 4
                     },
                     self.TITLE_INTEREST_REASON_FIELD: {
                         "type": "string",
-                        "description": "Brief explanation of title interest score (max 20 words)",
+                        "description": "Brief explanation of title interest "
+                                       "score (max 20 words)",
                         "maxLength": 100
                     }
                 },
-                "required": [self.LANGUAGE_FIELD,self.TITLE_INTEREST_FIELD,
+                "required": [self.LANGUAGE_FIELD, self.TITLE_INTEREST_FIELD,
                              self.TITLE_INTEREST_REASON_FIELD],
                 "additionalProperties": False
             }
         }
 
-    def _get_full_scoring_function_schema(self,ref_names: List[str]) -> Dict[
-        str,Any]:
+    def _get_full_scoring_function_schema(self, ref_names: List[str]) -> (
+            Dict)[str, Any]:
         """Create function schema for both reference and title scoring."""
         return {
             "name": "score_sheet",
-            "description": "Score references and title interest for a Jewish study sheet",
+            "description": "Score references and title interest for a Jewish "
+                           "study sheet",
             "parameters": {
                 "type": "object",
                 "properties": {
                     self.LANGUAGE_FIELD: {
                         "type": "string",
-                        "description": "# ISO‑639‑1 code inferred from *original user‑written* content",
+                        "description": "# ISO‑639‑1 code inferred from "
+                                       "*original user‑written* content",
                     },
                     self.REF_LEVELS_FIELD: {
                         "type": "object",
@@ -214,17 +236,19 @@ class SheetScorer:
                     },
                     self.TITLE_INTEREST_FIELD: {
                         "type": "integer",
-                        "description": "How interesting the title is to users (0-4 scale)",
+                        "description": "How interesting the title is to "
+                                       "users (0-4 scale)",
                         "minimum": 0,
                         "maximum": 4
                     },
                     self.TITLE_INTEREST_REASON_FIELD: {
                         "type": "string",
-                        "description": "Brief explanation of title interest score (max 20 words)",
+                        "description": "Brief explanation of title interest "
+                                       "score (max 20 words)",
                         "maxLength": 100
                     }
                 },
-                "required": [self.LANGUAGE_FIELD,self.REF_LEVELS_FIELD,
+                "required": [self.LANGUAGE_FIELD, self.REF_LEVELS_FIELD,
                              self.TITLE_INTEREST_FIELD,
                              self.TITLE_INTEREST_REASON_FIELD],
                 "additionalProperties": False
@@ -232,70 +256,72 @@ class SheetScorer:
         }
 
     @staticmethod
-    def chunk_list(lst: List[Any],n: int) -> Iterator[List[Any]]:
+    def chunk_list(lst: List[Any], n: int) -> Iterator[List[Any]]:
         """Yield successive n‑sized chunks from lst."""
-        for i in range(0,len(lst),n):
+        for i in range(0, len(lst), n):
             yield lst[i: i + n]
 
-    def _count_tokens(self,text: str) -> int:
+    def _count_tokens(self, text: str) -> int:
         """Rough token count; if no encoder, fall back to char heuristic."""
         try:
             encoding = tiktoken.encoding_for_model(self.model)
             return len(encoding.encode(text))
-        except (KeyError,ValueError) as e:
+        except (KeyError, ValueError) as e:
             logger.warning(
                 f"Could not get encoding for model {self.model}: {e}"
             )
             return len(text) // self.DEFAULT_TOKEN_CHAR_RATIO
 
-    def _invoke_llm(self,prompt: str) -> Dict[str,Any]:
+    def _invoke_llm(self, prompt: str) -> Dict[str, Any]:
         """Invoke LLM with prompt and parse JSON response."""
         response = self.llm([HumanMessage(content=prompt)])
         return json.loads(response.content)
 
-    def _create_title_only_prompt_function(self,sheet_title: str) -> str:
-        return f"""
-    You are scoring THE TITLE of a Jewish study sheet for how interesting it would be to users.
+    def _create_title_only_prompt_function(self, sheet_title: str) -> str:
+        return textwrap.dedent(
+            f"""You are scoring THE TITLE of a Jewish study sheet for how interesting it would be to users.
+    
+            SHEET TITLE:
+            {sheet_title}
+        
+            TASK: Return JSON with keys `title_interest_level` (0-4) and `title_interest_reason` ( < 20 words). 
+            Choose a higher score when the title:
+        
+            Title interest level (int 0–4):
+              0: Not interesting / off‑topic for users
+              1: Slight relevance, low pull
+              2: Somewhat interesting; user might skim
+              3: Interesting; user likely to open
+              4: Very compelling / must‑open
+            """)
 
-    SHEET TITLE:
-    {sheet_title}
-
-    TASK: Return JSON with keys `title_interest_level` (0-4) and `title_interest_reason` ( < 20 words). 
-    Choose a higher score when the title:
-
-    Title interest level (int 0–4):
-      0: Not interesting / off‑topic for users
-      1: Slight relevance, low pull
-      2: Somewhat interesting; user might skim
-      3: Interesting; user likely to open
-      4: Very compelling / must‑open
-    """
-
-    def _create_chunk_prompt_for_function(self,sheet_content: str,
+    def _create_chunk_prompt_for_function(self, sheet_content: str,
                                           ref_names: List[str]) -> str:
-        """Create prompt for function calling (no JSON format instructions needed)."""
+        """Create prompt for function calling (no JSON format instructions
+        needed)."""
         refs_md = "\n".join(f"- {r}" for r in ref_names)
-        return f"""
-You are analyzing a Jewish study sheet. Rate how much each listed reference 
-is discussed or central in the sheet.
+        return textwrap.dedent(
+            f"""
+            You are analyzing a Jewish study sheet. Rate how much each listed reference 
+            is discussed or central in the sheet.
 
-SHEET CONTENT:
-{sheet_content}
+            SHEET CONTENT:
+            {sheet_content}
 
-REFERENCES TO EVALUATE:
-{refs_md}
+            REFERENCES TO EVALUATE:
+            {refs_md}
 
-Scoring Scale (0-4):
-  0: Quoted only, no discussion
-  1: Mentioned only through neighboring verses
-  2: Moderate discussion (some commentary)
-  3: Significant discussion (substantial commentary)  
-  4: Central focus of sheet
+            Scoring Scale (0-4):
+              0: Quoted only, no discussion
+              1: Mentioned only through neighboring verses
+              2: Moderate discussion (some commentary)
+              3: Significant discussion (substantial commentary)
+              4: Central focus of sheet
 
-Score each reference based on how thoroughly it's discussed in the content.
-"""
+            Score each reference based on how thoroughly it's discussed in the content."""
+            )
 
-    def _create_final_chunk_prompt_for_function(self,sheet_content: str,
+    def _create_final_chunk_prompt_for_function(self, sheet_content: str,
                                                 ref_names: List[str],
                                                 sheet_title: str) -> str:
         """Create prompt for final chunk with title scoring using function
@@ -303,42 +329,42 @@ Score each reference based on how thoroughly it's discussed in the content.
         sheet_title_clean = sheet_title.strip() or "(untitled)"
         refs_md = "\n".join(f"- {r}" for r in ref_names)
 
-        return f"""
-Analyze this Jewish study sheet and provide two types of scores:
+        return textwrap.dedent(f"""
+            Analyze this Jewish study sheet and provide two types of scores:
+            
+            SHEET TITLE: {sheet_title_clean}
+            
+            SHEET CONTENT:
+            {sheet_content}
+            
+            REFERENCES TO EVALUATE:
+            {refs_md}
+            
+            TASKS:
+            1. Reference Discussion Scoring (0-4):
+               0: Quoted only, no discussion
+               1: Mentioned only through neighboring verses  
+               2: Moderate discussion (some commentary)
+               3: Significant discussion (substantial commentary)
+               4: Central focus of sheet
+            
+            2. Title Interest Scoring (0-4):
+               0: Not interesting/off-topic
+               1: Slight relevance, low appeal
+               2: Somewhat interesting; user might skim
+               3: Interesting; user likely to open
+               4: Very compelling/must-open
+            
+            Infer the language from the original user-written content.
+            """)
 
-SHEET TITLE: {sheet_title_clean}
-
-SHEET CONTENT:
-{sheet_content}
-
-REFERENCES TO EVALUATE:
-{refs_md}
-
-TASKS:
-1. Reference Discussion Scoring (0-4):
-   0: Quoted only, no discussion
-   1: Mentioned only through neighboring verses  
-   2: Moderate discussion (some commentary)
-   3: Significant discussion (substantial commentary)
-   4: Central focus of sheet
-
-2. Title Interest Scoring (0-4):
-   0: Not interesting/off-topic
-   1: Slight relevance, low appeal
-   2: Somewhat interesting; user might skim
-   3: Interesting; user likely to open
-   4: Very compelling/must-open
-
-Infer the language from the original user-written content.
-"""
-
-    def _validate_score_level(self,score: Any,
+    def _validate_score_level(self, score: Any,
                               field_name: str = "score") -> int:
         """Validate and normalize score to valid range."""
         if score not in self.VALID_LEVELS:
             try:
                 score = int(score)
-            except (ValueError,TypeError):
+            except (ValueError, TypeError):
                 logger.warning(
                     f"Invalid {field_name}: {score}, defaulting to 0"
                 )
@@ -347,7 +373,7 @@ Infer the language from the original user-written content.
             if score not in self.VALID_LEVELS:
                 clamped = max(
                     ScoreLevel.NOT_DISCUSSED,
-                    min(ScoreLevel.CENTRAL,score)
+                    min(ScoreLevel.CENTRAL, score)
                 )
                 logger.warning(
                     f"{field_name} {score} out of range, clamping to {clamped}"
@@ -383,13 +409,12 @@ Infer the language from the original user-written content.
         logger.info("Sending to LLM sheet without quotations text")
         return no_quotes_content
 
-
-    def _get_title_info(self,sheet_title: str) -> Dict[str,Any]:
+    def _get_title_info(self,sheet_title: str) -> Dict[str, Any]:
         """Obtain title-interest score ONLY (used when no content)."""
         prompt = self._create_title_only_prompt_function(sheet_title)
         try:
             function_schema = self._get_title_scoring_schema()
-            data = self._invoke_llm_with_function(prompt,function_schema)
+            data = self._invoke_llm_with_function(prompt, function_schema)
             title_level = self._validate_score_level(
                 data.get(self.TITLE_INTEREST_FIELD),
                 self.TITLE_INTEREST_FIELD
@@ -399,9 +424,9 @@ Infer the language from the original user-written content.
                 self.TITLE_INTEREST_FIELD:
                     title_level,
                 self.TITLE_INTEREST_REASON_FIELD:
-                    data.get(self.TITLE_INTEREST_REASON_FIELD,""),
+                    data.get(self.TITLE_INTEREST_REASON_FIELD, ""),
                 self.LANGUAGE_FIELD: data.get(
-                    self.LANGUAGE_FIELD,LanguageCode.DEFAULT
+                    self.LANGUAGE_FIELD, LanguageCode.DEFAULT
                 ),
             }
         except Exception as e:
@@ -415,21 +440,21 @@ Infer the language from the original user-written content.
     def _normalize_scores_to_percentages(
             self,
             sheet_tokens: int,
-            score_levels: Dict[str,int],
+            score_levels: Dict[str, int],
             beta: float = 1500  # token mass where no penalty
-    ) -> Dict[str,float]:
+    ) -> Dict[str, float]:
 
         total_level = sum(score_levels.values()) or 1
-        size_factor = min(1.0,sheet_tokens / beta)  # clamp to 1
+        size_factor = min(1.0, sheet_tokens / beta)  # clamp to 1
 
         # small sheets (few tokens) → size_factor < 1 → percentages shrink
         percentages = {
-            ref: round(level * 100 / total_level * size_factor,2)
-            for ref,level in score_levels.items()
+            ref: round(level * 100 / total_level * size_factor, 2)
+            for ref, level in score_levels.items()
         }
 
         norm = sum(percentages.values()) or 1
-        percentages = {r: round(v * 100 / norm,2) for r,v in
+        percentages = {r: round(v * 100 / norm, 2) for r, v in
                        percentages.items()}
         return percentages
 
@@ -440,7 +465,7 @@ Infer the language from the original user-written content.
             *,
             with_title: bool = False,
             sheet_title: str = ""
-    ) -> Tuple[Optional[Dict[str,Any]],Dict[str,int]]:
+    ) -> Tuple[Optional[Dict[str, Any]], Dict[str, int]]:
         """
         Robustly grade a list of refs.
         • First try the whole list.
@@ -448,52 +473,52 @@ Infer the language from the original user-written content.
           split the list in two and grade each half recursively.
         """
         if not refs:
-            return {},{}
+            return {}, {}
 
         try:
             if with_title:
                 prompt = self._create_final_chunk_prompt_for_function(
-                    content,refs,sheet_title
+                    content, refs, sheet_title
                 )
                 function_schema = self._get_full_scoring_function_schema(refs)
             else:
-                prompt = self._create_chunk_prompt_for_function(content,refs)
+                prompt = self._create_chunk_prompt_for_function(content, refs)
                 function_schema = self._get_reference_scoring_function_schema(
                     refs
                 )
             data,scores = self._get_gpt_ref_scores_function(
-                prompt,function_schema,refs
+                prompt, function_schema, refs
                 )
-            return data,scores
+            return data, scores
         except Exception:
             pass
 
         # fallback branch
         if len(refs) == 1:  # nothing left to split
-            return {},{refs[0]: ScoreLevel.NOT_DISCUSSED}
+            return {}, {refs[0]: ScoreLevel.NOT_DISCUSSED}
 
         mid = len(refs) // 2
         ld,ls = self._grade_refs_resilient(
-            content,refs[:mid],
+            content, refs[:mid],
             with_title=with_title,
             sheet_title=sheet_title
         )
         rd,rs = self._grade_refs_resilient(
-            content,refs[mid:],
+            content, refs[mid:],
             with_title=with_title,
             sheet_title=sheet_title
         )
-        merged_scores = {**ls,**rs}
+        merged_scores = {**ls, **rs}
         merged_data = ld or rd
-        return merged_data,merged_scores
+        return merged_data, merged_scores
 
-    def _get_gpt_ref_scores_function(self,prompt: str,function_schema,
+    def _get_gpt_ref_scores_function(self,prompt: str, function_schema,
                                      expected_refs: List[str]):
         try:
-            data = self._invoke_llm_with_function(prompt,function_schema)
-            chunk_scores = data.get(self.REF_LEVELS_FIELD,{})
+            data = self._invoke_llm_with_function(prompt, function_schema)
+            chunk_scores = data.get(self.REF_LEVELS_FIELD, {})
             validated_scores = {}
-            for ref,score in chunk_scores.items():
+            for ref, score in chunk_scores.items():
                 validated_scores[ref] = self._validate_score_level(
                     score,f"ref_score[{ref}]"
                 )
@@ -513,13 +538,14 @@ Infer the language from the original user-written content.
                         f"Missing {len(missing_refs)} references"
                     )
 
-            # Ensure we only include expected references (in case GPT returned extras)
+            # Ensure we only include expected references (in case GPT
+            # returned extras)
             final_scores = {
-                ref: validated_scores.get(ref,ScoreLevel.NOT_DISCUSSED) for ref
+                ref: validated_scores.get(ref, ScoreLevel.NOT_DISCUSSED) for ref
                 in expected_refs}
 
             data[self.REF_SCORES_FIELD] = final_scores
-            return data,final_scores
+            return data, final_scores
 
         except IncompleteScoreError:
             raise
@@ -528,7 +554,7 @@ Infer the language from the original user-written content.
             logger.error(f"Chunk GPT failed: {e}")
             return None
 
-    def _last_regular_start(self,n: int,chunk: int,overlap: int) -> int:
+    def _last_regular_start(self, n: int, chunk: int, overlap: int) -> int:
         """
         Return the index where the *final* chunk (with title) should start.
         If the total length fits into one chunk plus the allowed overlap,
@@ -537,25 +563,25 @@ Infer the language from the original user-written content.
         if n <= chunk + overlap:
             return 0
         step = chunk - overlap
-        return max(0,n - chunk) if step <= 0 else (n - chunk)
+        return max(0, n - chunk) if step <= 0 else (n - chunk)
 
     def _process_reference_chunks(
             self,
             content: str,
             ref_names: List[str]
-    ) -> Optional[Dict[str,int]]:
+    ) -> Optional[Dict[str, int]]:
         """Process reference chunks in batches."""
-        ref_scores: Dict[str,int] = {}
+        ref_scores: Dict[str, int] = {}
 
         last_chunk_start = self._last_regular_start(
-            len(ref_names),self.chunk_size,self.MAX_CHUNK_OVERLAP
+            len(ref_names), self.chunk_size, self.MAX_CHUNK_OVERLAP
         )
 
         for chunk in self.chunk_list(
-                ref_names[:last_chunk_start],self.chunk_size
+                ref_names[:last_chunk_start], self.chunk_size
         ):
             # prompt = self._create_chunk_prompt(content,chunk)
-            _,chunk_scores = self._grade_refs_resilient(
+            _, chunk_scores = self._grade_refs_resilient(
                 content=content,
                 refs=chunk,
                 with_title=False
@@ -571,10 +597,10 @@ Infer the language from the original user-written content.
             content: str,
             ref_names: List[str],
             title: str,
-    ) -> Optional[Dict[str,Any]]:
+    ) -> Optional[Dict[str, Any]]:
         """Process final chunk and get title scores."""
         start = self._last_regular_start(
-            len(ref_names),self.chunk_size,self.MAX_CHUNK_OVERLAP
+            len(ref_names), self.chunk_size, self.MAX_CHUNK_OVERLAP
         )
         final_chunk = ref_names[start:]
 
@@ -589,7 +615,7 @@ Infer the language from the original user-written content.
         if result is None:
             return None
 
-        data,_ = result
+        data, _ = result
         return data
 
     def get_gpt_scores(
@@ -597,22 +623,22 @@ Infer the language from the original user-written content.
             content: str,
             ref_names: List[str],
             title: str,
-    ) -> Optional[Dict[str,Any]]:
+    ) -> Optional[Dict[str, Any]]:
         """Get GPT scores for references and title."""
         # Process reference chunks
-        ref_scores = self._process_reference_chunks(content,ref_names)
+        ref_scores = self._process_reference_chunks(content, ref_names)
         if ref_scores is None:
             return None
 
         # Process final chunk with title
         final_data = self._process_final_chunk_with_title(
-            content,ref_names,title
+            content, ref_names, title
         )
         if final_data is None:
             return None
 
         # Combine scores
-        final_chunk_scores = final_data.get(self.REF_SCORES_FIELD,{})
+        final_chunk_scores = final_data.get(self.REF_SCORES_FIELD, {})
         ref_scores.update(final_chunk_scores)
 
         # # Normalize to percentages
@@ -629,17 +655,17 @@ Infer the language from the original user-written content.
 
         return {
             self.LANGUAGE_FIELD: final_data.get(
-                self.LANGUAGE_FIELD,LanguageCode.DEFAULT
+                self.LANGUAGE_FIELD, LanguageCode.DEFAULT
             ),
             self.REF_LEVELS_FIELD: ref_scores,
             self.REF_SCORES_FIELD: score_percentages,
             self.TITLE_INTEREST_FIELD: title_level,
             self.TITLE_INTEREST_REASON_FIELD: final_data.get(
-                self.TITLE_INTEREST_REASON_FIELD,""
+                self.TITLE_INTEREST_REASON_FIELD, ""
             ),
         }
 
-    def _truncate_to_token_budget(self,text: str,max_tokens: int) -> str:
+    def _truncate_to_token_budget(self, text: str, max_tokens: int) -> str:
         """Truncate text to fit within token budget using LLM summarization."""
         if self._count_tokens(text) <= max_tokens:
             return text
@@ -666,13 +692,13 @@ Infer the language from the original user-written content.
             # Fallback: character-based truncation
             return text[:max_tokens * self.DEFAULT_TOKEN_CHAR_RATIO]
 
-    def process_sheet_by_content(self,sheet: Dict[str,Any],
-                                 add_full_commentary=False) -> Optional[
-        Dict[str,Any]]:
+    def process_sheet_by_content(self, sheet: Dict[str, Any],
+                                 add_full_commentary=False) -> (
+            Optional)[Dict[str, Any]]:
         """Score a single sheet based on its content."""
         sheet_id = str(sheet.get(self.SHEET_ID_FIELD))
-        ref_names = sheet.get("expandedRefs",[])
-        sheet_title = sheet.get("title","")
+        ref_names = sheet.get("expandedRefs", [])
+        sheet_title = sheet.get("title", "")
 
         if not ref_names:
             logger.info(f"No expanded refs for sheet {sheet_id}, skipping")
@@ -699,13 +725,13 @@ Infer the language from the original user-written content.
                 self.PROCESSED_AT_FIELD: datetime.utcnow(),
                 **title_info
             }
-        content = self._sheet_to_text(no_quotes_content=no_quotes_content,
-                                                  full_content=full_content,
-                                                  max_tokens=self.max_prompt_tokens-
-                                                  self.token_margin,
-                                                  add_full_commentary=add_full_commentary)
+        content = self._sheet_to_text(
+            no_quotes_content=no_quotes_content,
+            full_content=full_content,
+            max_tokens=self.max_prompt_tokens-self.token_margin,
+            add_full_commentary=add_full_commentary)
         # Process with GPT
-        gpt_analysis = self.get_gpt_scores(content,ref_names,sheet_title)
+        gpt_analysis = self.get_gpt_scores(content, ref_names, sheet_title)
         if not gpt_analysis:
             logger.error(f"Failed to get GPT scores for sheet {sheet_id}")
             return None

--- a/app/sheet_scoring/openai_sheets_scorer.py
+++ b/app/sheet_scoring/openai_sheets_scorer.py
@@ -1,0 +1,722 @@
+import json
+import logging
+from datetime import datetime
+from enum import IntEnum
+from typing import Any,Dict,Iterator,List,Optional,Set,Tuple
+
+import tiktoken
+from langchain.schema import HumanMessage
+from langchain_openai import ChatOpenAI
+
+from app.sheet_scoring.text_utils import sheet_to_text_views
+
+# Configure logging
+logger = logging.getLogger(__name__)
+
+
+class IncompleteScoreError(Exception):
+    """Raised when LLM JSON is valid but doesn’t cover every reference."""
+    pass
+
+
+class ScoreLevel(IntEnum):
+    """Reference discussion and title interest levels."""
+    NOT_DISCUSSED = 0
+    MINIMAL = 1
+    MODERATE = 2
+    SIGNIFICANT = 3
+    CENTRAL = 4
+
+
+class LanguageCode:
+    """Supported language codes."""
+    ENGLISH = 'en'
+    HEBREW = 'he'
+    DEFAULT = ENGLISH
+
+
+class SheetScorer:
+    """
+    Scores Jewish study sheets for reference relevance and title interest using LLMs,
+    computes creativity score based on percentage of user generated content.
+
+    This class processes sheets from MongoDB, analyzes their content using OpenAI's GPT models,
+    and assigns scores for how well each biblical reference is discussed and how interesting
+    the sheet title is to users.
+    """
+
+    # Configuration constants
+    DEFAULT_MAX_OUTPUT_TOKENS = 16384
+    DEFAULT_CHUNK_SIZE = 80
+    DEFAULT_MAX_INPUT_OUTPUT_TOKENS = 128000
+    DEFAULT_MAX_REFS_TO_PROCESS = 800
+    DEFAULT_TOKEN_CHAR_RATIO = 3
+    MAX_CHUNK_OVERLAP = 10
+    # Database field names
+    REF_SCORES_FIELD = "ref_scores"
+    REF_LEVELS_FIELD = "ref_levels"
+    TITLE_INTEREST_FIELD = "title_interest_level"
+    LANGUAGE_FIELD = "language"
+    TITLE_INTEREST_REASON_FIELD = 'title_interest_reason'
+    SHEET_ID_FIELD = "_id"
+    PROCESSED_AT_FIELD = "processed_at"
+    CREATIVITY_SCORE_FIELD = 'creativity_score'
+
+    # Valid score levels
+    VALID_LEVELS: Set[int] = {level.value for level in ScoreLevel}
+
+    def __init__(
+            self,
+            api_key: Optional[str],
+            model: str = "gpt-4o-mini",
+            max_prompt_tokens: int = DEFAULT_MAX_INPUT_OUTPUT_TOKENS,
+            token_margin: int = DEFAULT_MAX_OUTPUT_TOKENS,
+            max_ref_to_process: int = DEFAULT_MAX_REFS_TO_PROCESS,
+            chunk_size: int = DEFAULT_CHUNK_SIZE,
+
+    ):
+        self.max_prompt_tokens = max_prompt_tokens
+        self.token_margin = token_margin
+        self.model = model
+        self.chunk_size = chunk_size
+        self.max_ref_to_process = max_ref_to_process
+        self.llm = self._create_json_llm(api_key,model)
+        self.summarizer = self._create_text_llm(api_key,model)
+
+    def _create_json_llm(self,api_key: str,model: str) -> ChatOpenAI:
+        """Create LLM client for JSON responses."""
+        return ChatOpenAI(
+            model=model,
+            temperature=0,
+            top_p=0,
+            frequency_penalty=0,
+            presence_penalty=0,
+            seed=42,
+            api_key=api_key,
+        )
+
+    def _create_text_llm(self,api_key: str,model: str) -> ChatOpenAI:
+        """Create LLM client for text responses."""
+        return ChatOpenAI(
+            model=model,
+            temperature=0,
+            model_kwargs={"response_format": {"type": "text"}},
+            api_key=api_key,
+        )
+
+    def _invoke_llm_with_function(self,prompt: str,
+                                  function_schema: Dict[str,Any]) -> Dict[
+        str,Any]:
+        """Invoke LLM using function calling instead of JSON mode."""
+        response = self.llm.invoke(
+            [HumanMessage(content=prompt)],
+            functions=[function_schema],
+            function_call={"name": function_schema["name"]}
+        )
+
+        # Extract function call arguments
+        if hasattr(
+                response,'additional_kwargs'
+        ) and 'function_call' in response.additional_kwargs:
+            function_call = response.additional_kwargs['function_call']
+            return json.loads(function_call['arguments'])
+        else:
+            raise ValueError("No function call in response")
+
+    def _get_reference_scoring_function_schema(self,ref_names: List[str]) -> \
+            Dict[str,Any]:
+        """Create function schema for reference scoring with exact reference names."""
+        return {
+            "name": "score_references",
+            "description": "Score how well each biblical reference is discussed in the sheet",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    self.REF_LEVELS_FIELD: {
+                        "type": "object",
+                        "description": "Scores for each reference (0-4 scale)",
+                        "properties": {
+                            ref_name: {
+                                "type": "integer",
+                                "description": f"Discussion level for {ref_name}",
+                                "minimum": 0,
+                                "maximum": 4
+                            }
+                            for ref_name in ref_names
+                        },
+                        "required": ref_names,
+                        "additionalProperties": False
+                    }
+                },
+                "required": [self.REF_LEVELS_FIELD],
+                "additionalProperties": False
+            }
+        }
+
+    def _get_title_scoring_schema(self) -> Dict[
+        str,Any]:
+        """Create function schema for both reference and title scoring."""
+        return {
+            "name": "score_title",
+            "description": "Score title interest for a Jewish study sheet",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    self.LANGUAGE_FIELD: {
+                        "type": "string",
+                        "description": "ISO-639-1 title language code",
+                    },
+                    self.TITLE_INTEREST_FIELD: {
+                        "type": "integer",
+                        "description": "How interesting the title is to users (0-4 scale)",
+                        "minimum": 0,
+                        "maximum": 4
+                    },
+                    self.TITLE_INTEREST_REASON_FIELD: {
+                        "type": "string",
+                        "description": "Brief explanation of title interest score (max 20 words)",
+                        "maxLength": 100
+                    }
+                },
+                "required": [self.LANGUAGE_FIELD,self.TITLE_INTEREST_FIELD,
+                             self.TITLE_INTEREST_REASON_FIELD],
+                "additionalProperties": False
+            }
+        }
+
+    def _get_full_scoring_function_schema(self,ref_names: List[str]) -> Dict[
+        str,Any]:
+        """Create function schema for both reference and title scoring."""
+        return {
+            "name": "score_sheet",
+            "description": "Score references and title interest for a Jewish study sheet",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    self.LANGUAGE_FIELD: {
+                        "type": "string",
+                        "description": "# ISO‑639‑1 code inferred from *original user‑written* content",
+                    },
+                    self.REF_LEVELS_FIELD: {
+                        "type": "object",
+                        "description": "Scores for each reference (0-4 scale)",
+                        "properties": {
+                            ref_name: {
+                                "type": "integer",
+                                "description": f"Discussion level for {ref_name}",
+                                "minimum": 0,
+                                "maximum": 4
+                            }
+                            for ref_name in ref_names
+                        },
+                        "required": ref_names,
+                        "additionalProperties": False
+                    },
+                    self.TITLE_INTEREST_FIELD: {
+                        "type": "integer",
+                        "description": "How interesting the title is to users (0-4 scale)",
+                        "minimum": 0,
+                        "maximum": 4
+                    },
+                    self.TITLE_INTEREST_REASON_FIELD: {
+                        "type": "string",
+                        "description": "Brief explanation of title interest score (max 20 words)",
+                        "maxLength": 100
+                    }
+                },
+                "required": [self.LANGUAGE_FIELD,self.REF_LEVELS_FIELD,
+                             self.TITLE_INTEREST_FIELD,
+                             self.TITLE_INTEREST_REASON_FIELD],
+                "additionalProperties": False
+            }
+        }
+
+    @staticmethod
+    def chunk_list(lst: List[Any],n: int) -> Iterator[List[Any]]:
+        """Yield successive n‑sized chunks from lst."""
+        for i in range(0,len(lst),n):
+            yield lst[i: i + n]
+
+    def _count_tokens(self,text: str) -> int:
+        """Rough token count; if no encoder, fall back to char heuristic."""
+        try:
+            encoding = tiktoken.encoding_for_model(self.model)
+            return len(encoding.encode(text))
+        except (KeyError,ValueError) as e:
+            logger.warning(
+                f"Could not get encoding for model {self.model}: {e}"
+            )
+            return len(text) // self.DEFAULT_TOKEN_CHAR_RATIO
+
+    def _invoke_llm(self,prompt: str) -> Dict[str,Any]:
+        """Invoke LLM with prompt and parse JSON response."""
+        response = self.llm([HumanMessage(content=prompt)])
+        return json.loads(response.content)
+
+    def _create_title_only_prompt_function(self,sheet_title: str) -> str:
+        return f"""
+    You are scoring THE TITLE of a Jewish study sheet for how interesting it would be to users.
+
+    SHEET TITLE:
+    {sheet_title}
+
+    TASK: Return JSON with keys `title_interest_level` (0-4) and `title_interest_reason` ( < 20 words). 
+    Choose a higher score when the title:
+
+    Title interest level (int 0–4):
+      0: Not interesting / off‑topic for users
+      1: Slight relevance, low pull
+      2: Somewhat interesting; user might skim
+      3: Interesting; user likely to open
+      4: Very compelling / must‑open
+    """
+
+    def _create_chunk_prompt_for_function(self,sheet_content: str,
+                                          ref_names: List[str]) -> str:
+        """Create prompt for function calling (no JSON format instructions needed)."""
+        refs_md = "\n".join(f"- {r}" for r in ref_names)
+        return f"""
+You are analyzing a Jewish study sheet. Rate how much each listed reference 
+is discussed or central in the sheet.
+
+SHEET CONTENT:
+{sheet_content}
+
+REFERENCES TO EVALUATE:
+{refs_md}
+
+Scoring Scale (0-4):
+  0: Quoted only, no discussion
+  1: Mentioned only through neighboring verses
+  2: Moderate discussion (some commentary)
+  3: Significant discussion (substantial commentary)  
+  4: Central focus of sheet
+
+Score each reference based on how thoroughly it's discussed in the content.
+"""
+
+    def _create_final_chunk_prompt_for_function(self,sheet_content: str,
+                                                ref_names: List[str],
+                                                sheet_title: str) -> str:
+        """Create prompt for final chunk with title scoring using function
+        calling."""
+        sheet_title_clean = sheet_title.strip() or "(untitled)"
+        refs_md = "\n".join(f"- {r}" for r in ref_names)
+
+        return f"""
+Analyze this Jewish study sheet and provide two types of scores:
+
+SHEET TITLE: {sheet_title_clean}
+
+SHEET CONTENT:
+{sheet_content}
+
+REFERENCES TO EVALUATE:
+{refs_md}
+
+TASKS:
+1. Reference Discussion Scoring (0-4):
+   0: Quoted only, no discussion
+   1: Mentioned only through neighboring verses  
+   2: Moderate discussion (some commentary)
+   3: Significant discussion (substantial commentary)
+   4: Central focus of sheet
+
+2. Title Interest Scoring (0-4):
+   0: Not interesting/off-topic
+   1: Slight relevance, low appeal
+   2: Somewhat interesting; user might skim
+   3: Interesting; user likely to open
+   4: Very compelling/must-open
+
+Infer the language from the original user-written content.
+"""
+
+    def _validate_score_level(self,score: Any,
+                              field_name: str = "score") -> int:
+        """Validate and normalize score to valid range."""
+        if score not in self.VALID_LEVELS:
+            try:
+                score = int(score)
+            except (ValueError,TypeError):
+                logger.warning(
+                    f"Invalid {field_name}: {score}, defaulting to 0"
+                )
+                return ScoreLevel.NOT_DISCUSSED
+
+            if score not in self.VALID_LEVELS:
+                clamped = max(
+                    ScoreLevel.NOT_DISCUSSED,
+                    min(ScoreLevel.CENTRAL,score)
+                )
+                logger.warning(
+                    f"{field_name} {score} out of range, clamping to {clamped}"
+                )
+                return clamped
+
+        return score
+
+    def _sheet_to_text(
+        self,
+        no_quotes_content: str,
+        full_content: str,
+        max_tokens: int,
+        add_full_commentary: bool
+    ) -> str:
+        """
+        Build a text snapshot of the sheet with an *all‑or‑nothing* rule:
+        • Always include every bit of author commentary.
+        • Append *all* canonical quotations only if the whole bundle still
+          fits into `max_tokens`.
+        """
+        comm_tokens = self._count_tokens(no_quotes_content)
+        # Commentary alone is already bigger than the budget → truncate & quit
+        full_tokens = self._count_tokens(full_content)
+        if add_full_commentary:
+            if full_tokens <= max_tokens:
+                logger.info("Sending to LLM sheet with quotations")
+                return full_content
+
+        if comm_tokens >= max_tokens:
+            logger.info("Truncating user commentaries")
+            return self._truncate_to_token_budget(no_quotes_content, max_tokens)
+        logger.info("Sending to LLM sheet without quotations text")
+        return no_quotes_content
+
+
+    def _get_title_info(self,sheet_title: str) -> Dict[str,Any]:
+        """Obtain title-interest score ONLY (used when no content)."""
+        prompt = self._create_title_only_prompt_function(sheet_title)
+        try:
+            function_schema = self._get_title_scoring_schema()
+            data = self._invoke_llm_with_function(prompt,function_schema)
+            title_level = self._validate_score_level(
+                data.get(self.TITLE_INTEREST_FIELD),
+                self.TITLE_INTEREST_FIELD
+            )
+
+            return {
+                self.TITLE_INTEREST_FIELD:
+                    title_level,
+                self.TITLE_INTEREST_REASON_FIELD:
+                    data.get(self.TITLE_INTEREST_REASON_FIELD,""),
+                self.LANGUAGE_FIELD: data.get(
+                    self.LANGUAGE_FIELD,LanguageCode.DEFAULT
+                ),
+            }
+        except Exception as e:
+            logger.error(f"Title-only GPT attempt failed: {e}")
+            return {
+                self.TITLE_INTEREST_FIELD: ScoreLevel.NOT_DISCUSSED,
+                self.TITLE_INTEREST_REASON_FIELD: "LLM error",
+                self.LANGUAGE_FIELD: LanguageCode.DEFAULT
+            }
+
+    def _normalize_scores_to_percentages(
+            self,
+            sheet_tokens: int,
+            score_levels: Dict[str,int],
+            beta: float = 1500  # token mass where no penalty
+    ) -> Dict[str,float]:
+
+        total_level = sum(score_levels.values()) or 1
+        size_factor = min(1.0,sheet_tokens / beta)  # clamp to 1
+
+        # small sheets (few tokens) → size_factor < 1 → percentages shrink
+        percentages = {
+            ref: round(level * 100 / total_level * size_factor,2)
+            for ref,level in score_levels.items()
+        }
+
+        norm = sum(percentages.values()) or 1
+        percentages = {r: round(v * 100 / norm,2) for r,v in
+                       percentages.items()}
+        return percentages
+
+    def _grade_refs_resilient(
+            self,
+            content: str,
+            refs: List[str],
+            *,
+            with_title: bool = False,
+            sheet_title: str = ""
+    ) -> Tuple[Optional[Dict[str,Any]],Dict[str,int]]:
+        """
+        Robustly grade a list of refs.
+        • First try the whole list.
+        • If the model returns < len(refs) scores (or JSON error),
+          split the list in two and grade each half recursively.
+        """
+        if not refs:
+            return {},{}
+
+        try:
+            if with_title:
+                prompt = self._create_final_chunk_prompt_for_function(
+                    content,refs,sheet_title
+                )
+                function_schema = self._get_full_scoring_function_schema(refs)
+            else:
+                prompt = self._create_chunk_prompt_for_function(content,refs)
+                function_schema = self._get_reference_scoring_function_schema(
+                    refs
+                )
+            data,scores = self._get_gpt_ref_scores_function(
+                prompt,function_schema,refs
+                )
+            return data,scores
+        except Exception:
+            pass
+
+        # fallback branch
+        if len(refs) == 1:  # nothing left to split
+            return {},{refs[0]: ScoreLevel.NOT_DISCUSSED}
+
+        mid = len(refs) // 2
+        ld,ls = self._grade_refs_resilient(
+            content,refs[:mid],
+            with_title=with_title,
+            sheet_title=sheet_title
+        )
+        rd,rs = self._grade_refs_resilient(
+            content,refs[mid:],
+            with_title=with_title,
+            sheet_title=sheet_title
+        )
+        merged_scores = {**ls,**rs}
+        merged_data = ld or rd
+        return merged_data,merged_scores
+
+    def _get_gpt_ref_scores_function(self,prompt: str,function_schema,
+                                     expected_refs: List[str]):
+        try:
+            data = self._invoke_llm_with_function(prompt,function_schema)
+            chunk_scores = data.get(self.REF_LEVELS_FIELD,{})
+            validated_scores = {}
+            for ref,score in chunk_scores.items():
+                validated_scores[ref] = self._validate_score_level(
+                    score,f"ref_score[{ref}]"
+                )
+
+            # Check for missing references and assign default scores (0)
+            missing_refs = set(expected_refs) - set(validated_scores.keys())
+            if missing_refs:
+                logger.warning(
+                    f"GPT didn't return scores for {len(missing_refs)} references: {list(missing_refs)[:5]}... - defaulting to 0"
+                )
+                if len(missing_refs) < 5:
+                    for ref in missing_refs:
+                        validated_scores[
+                            ref] = ScoreLevel.NOT_DISCUSSED
+                else:
+                    raise IncompleteScoreError(
+                        f"Missing {len(missing_refs)} references"
+                    )
+
+            # Ensure we only include expected references (in case GPT returned extras)
+            final_scores = {
+                ref: validated_scores.get(ref,ScoreLevel.NOT_DISCUSSED) for ref
+                in expected_refs}
+
+            data[self.REF_SCORES_FIELD] = final_scores
+            return data,final_scores
+
+        except IncompleteScoreError:
+            raise
+
+        except Exception as e:
+            logger.error(f"Chunk GPT failed: {e}")
+            return None
+
+    def _last_regular_start(self,n: int,chunk: int,overlap: int) -> int:
+        """
+        Return the index where the *final* chunk (with title) should start.
+        If the total length fits into one chunk plus the allowed overlap,
+        analyse everything together (start = 0).
+        """
+        if n <= chunk + overlap:
+            return 0
+        step = chunk - overlap
+        return max(0,n - chunk) if step <= 0 else (n - chunk)
+
+    def _process_reference_chunks(
+            self,
+            content: str,
+            ref_names: List[str]
+    ) -> Optional[Dict[str,int]]:
+        """Process reference chunks in batches."""
+        ref_scores: Dict[str,int] = {}
+
+        last_chunk_start = self._last_regular_start(
+            len(ref_names),self.chunk_size,self.MAX_CHUNK_OVERLAP
+        )
+
+        for chunk in self.chunk_list(
+                ref_names[:last_chunk_start],self.chunk_size
+        ):
+            # prompt = self._create_chunk_prompt(content,chunk)
+            _,chunk_scores = self._grade_refs_resilient(
+                content=content,
+                refs=chunk,
+                with_title=False
+            )
+            if chunk_scores is None:
+                return None
+            ref_scores.update(chunk_scores)
+
+        return ref_scores
+
+    def _process_final_chunk_with_title(
+            self,
+            content: str,
+            ref_names: List[str],
+            title: str,
+    ) -> Optional[Dict[str,Any]]:
+        """Process final chunk and get title scores."""
+        start = self._last_regular_start(
+            len(ref_names),self.chunk_size,self.MAX_CHUNK_OVERLAP
+        )
+        final_chunk = ref_names[start:]
+
+        # prompt = self._create_final_chunk_prompt(content,final_chunk,title)
+        result = self._grade_refs_resilient(
+            content=content,
+            refs=final_chunk,
+            with_title=True,
+            sheet_title=title
+        )
+
+        if result is None:
+            return None
+
+        data,_ = result
+        return data
+
+    def get_gpt_scores(
+            self,
+            content: str,
+            ref_names: List[str],
+            title: str,
+    ) -> Optional[Dict[str,Any]]:
+        """Get GPT scores for references and title."""
+        # Process reference chunks
+        ref_scores = self._process_reference_chunks(content,ref_names)
+        if ref_scores is None:
+            return None
+
+        # Process final chunk with title
+        final_data = self._process_final_chunk_with_title(
+            content,ref_names,title
+        )
+        if final_data is None:
+            return None
+
+        # Combine scores
+        final_chunk_scores = final_data.get(self.REF_SCORES_FIELD,{})
+        ref_scores.update(final_chunk_scores)
+
+        # # Normalize to percentages
+        score_percentages = self._normalize_scores_to_percentages(
+            score_levels=ref_scores,
+            sheet_tokens=self._count_tokens(content)
+        )
+
+        # Validate title score
+        title_level = self._validate_score_level(
+            final_data.get(self.TITLE_INTEREST_FIELD),
+            self.TITLE_INTEREST_FIELD
+        )
+
+        return {
+            self.LANGUAGE_FIELD: final_data.get(
+                self.LANGUAGE_FIELD,LanguageCode.DEFAULT
+            ),
+            self.REF_LEVELS_FIELD: ref_scores,
+            self.REF_SCORES_FIELD: score_percentages,
+            self.TITLE_INTEREST_FIELD: title_level,
+            self.TITLE_INTEREST_REASON_FIELD: final_data.get(
+                self.TITLE_INTEREST_REASON_FIELD,""
+            ),
+        }
+
+    def _truncate_to_token_budget(self,text: str,max_tokens: int) -> str:
+        """Truncate text to fit within token budget using LLM summarization."""
+        if self._count_tokens(text) <= max_tokens:
+            return text
+        try:
+            prompt = f"""
+            Compress the following commentary to ≤ {max_tokens} tokens.
+            Keep every reference tag like "Genesis 1:1" or "Exodus 2:5".
+            Use clear sentences; preserve main ideas.
+
+            {text}
+            """
+            summary = self.summarizer(
+                [HumanMessage(content=prompt)]
+            ).content.strip()
+
+            if self._count_tokens(summary) <= max_tokens:
+                return summary
+            else:
+                # Fallback: character-based truncation
+                return summary[:max_tokens * self.DEFAULT_TOKEN_CHAR_RATIO]
+
+        except Exception as e:
+            logger.error(f"Summarization failed: {e}")
+            # Fallback: character-based truncation
+            return text[:max_tokens * self.DEFAULT_TOKEN_CHAR_RATIO]
+
+    def process_sheet_by_content(self,sheet: Dict[str,Any],
+                                 add_full_commentary=False) -> Optional[
+        Dict[str,Any]]:
+        """Score a single sheet based on its content."""
+        sheet_id = str(sheet.get(self.SHEET_ID_FIELD))
+        ref_names = sheet.get("expandedRefs",[])
+        sheet_title = sheet.get("title","")
+
+        if not ref_names:
+            logger.info(f"No expanded refs for sheet {sheet_id}, skipping")
+            return None
+
+        (quotes_only,
+         no_quotes_content,
+         full_content,
+         has_original, creativity_score) = sheet_to_text_views(sheet,
+                                                         LanguageCode.DEFAULT)
+
+        # Check for original content and reference limits
+        if (not has_original or
+                len(ref_names) > self.max_ref_to_process):
+            logger.info(f"Sheet {sheet_id}: using equal distribution")
+            score_percentages = {ref: 0 for ref in ref_names}
+            title_info = self._get_title_info(sheet_title)
+
+            return {
+                self.SHEET_ID_FIELD: sheet_id,
+                self.REF_LEVELS_FIELD: score_percentages,
+                self.CREATIVITY_SCORE_FIELD: creativity_score,
+                self.REF_SCORES_FIELD: score_percentages,
+                self.PROCESSED_AT_FIELD: datetime.utcnow(),
+                **title_info
+            }
+        content = self._sheet_to_text(no_quotes_content=no_quotes_content,
+                                                  full_content=full_content,
+                                                  max_tokens=self.max_prompt_tokens-
+                                                  self.token_margin,
+                                                  add_full_commentary=add_full_commentary)
+        # Process with GPT
+        gpt_analysis = self.get_gpt_scores(content,ref_names,sheet_title)
+        if not gpt_analysis:
+            logger.error(f"Failed to get GPT scores for sheet {sheet_id}")
+            return None
+        return {
+            self.SHEET_ID_FIELD: sheet_id,
+            self.CREATIVITY_SCORE_FIELD: creativity_score,
+            self.REF_SCORES_FIELD: gpt_analysis[self.REF_SCORES_FIELD],
+            self.REF_LEVELS_FIELD: gpt_analysis[self.REF_LEVELS_FIELD],
+            self.PROCESSED_AT_FIELD: datetime.utcnow(),
+            self.LANGUAGE_FIELD: gpt_analysis[self.LANGUAGE_FIELD],
+            self.TITLE_INTEREST_FIELD: gpt_analysis[self.TITLE_INTEREST_FIELD],
+            self.TITLE_INTEREST_REASON_FIELD:
+                gpt_analysis[self.TITLE_INTEREST_REASON_FIELD],
+        }

--- a/app/sheet_scoring/sheet_scoring.py
+++ b/app/sheet_scoring/sheet_scoring.py
@@ -1,19 +1,15 @@
-from .openai_sheets_scorer import SheetScorer
+from sheet_scoring.openai_sheets_scorer import SheetScorer
 import os
 from pathlib import Path
 from sefaria_llm_interface.scoring_io import (
     SheetScoringInput,
     SheetScoringOutput,
 )
-from dotenv import load_dotenv
 
-load_dotenv(Path(__file__).parent / "secrets.env")   # adjust path if needed
 
 def score_one_sheet(inp: SheetScoringInput) -> SheetScoringOutput:
-
     scorer = SheetScorer(
-            api_key=os.getenv("OPENAI_API_KEY"),
-        )
+        api_key=os.getenv("OPENAI_API_KEY"))
     result = scorer.process_sheet_by_content(sheet=inp.sheet_content)
     if not result:
         return SheetScoringOutput(
@@ -24,7 +20,7 @@ def score_one_sheet(inp: SheetScoringInput) -> SheetScoringOutput:
             title_interest_reason="",
             language="",
             creativity_score=0,
-            processed_at=None,
+            processed_datetime=None,
         )
     return SheetScoringOutput(
         sheet_id=result[scorer.SHEET_ID_FIELD],
@@ -34,7 +30,5 @@ def score_one_sheet(inp: SheetScoringInput) -> SheetScoringOutput:
         title_interest_reason=result[scorer.TITLE_INTEREST_REASON_FIELD],
         language=result[scorer.LANGUAGE_FIELD],
         creativity_score=result[scorer.CREATIVITY_SCORE_FIELD],
-        processed_at=result["processed_at"].isoformat(),
+        processed_datetime=result["processed_datetime"].isoformat(),
     )
-
-

--- a/app/sheet_scoring/sheet_scoring.py
+++ b/app/sheet_scoring/sheet_scoring.py
@@ -1,0 +1,40 @@
+from .openai_sheets_scorer import SheetScorer
+import os
+from pathlib import Path
+from sefaria_llm_interface.scoring_io import (
+    SheetScoringInput,
+    SheetScoringOutput,
+)
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).parent / "secrets.env")   # adjust path if needed
+
+def score_one_sheet(inp: SheetScoringInput) -> SheetScoringOutput:
+
+    scorer = SheetScorer(
+            api_key=os.getenv("OPENAI_API_KEY"),
+        )
+    result = scorer.process_sheet_by_content(sheet=inp.sheet_content)
+    if not result:
+        return SheetScoringOutput(
+            sheet_id=result[scorer.SHEET_ID_FIELD],
+            ref_scores={},
+            ref_levels={},
+            title_interest_level=0,
+            title_interest_reason="",
+            language="",
+            creativity_score=0,
+            processed_at=None,
+        )
+    return SheetScoringOutput(
+        sheet_id=result[scorer.SHEET_ID_FIELD],
+        ref_scores=result[scorer.REF_SCORES_FIELD],
+        ref_levels=result[scorer.REF_LEVELS_FIELD],
+        title_interest_level=result[scorer.TITLE_INTEREST_FIELD],
+        title_interest_reason=result[scorer.TITLE_INTEREST_REASON_FIELD],
+        language=result[scorer.LANGUAGE_FIELD],
+        creativity_score=result[scorer.CREATIVITY_SCORE_FIELD],
+        processed_at=result["processed_at"].isoformat(),
+    )
+
+

--- a/app/sheet_scoring/tasks.py
+++ b/app/sheet_scoring/tasks.py
@@ -1,5 +1,5 @@
 from celery import shared_task
-from .sheet_scoring import score_one_sheet
+from sheet_scoring.sheet_scoring import score_one_sheet
 from sefaria_llm_interface.scoring_io import (
     SheetScoringInput
 )
@@ -7,7 +7,7 @@ from dataclasses import asdict
 
 
 @shared_task(name='llm.score_sheet')
-def score_sheet_task(raw_input:dict) -> dict:
+def score_sheet_task(raw_input: dict) -> dict:
     inp = SheetScoringInput(**raw_input)
     out = score_one_sheet(inp)
     return asdict(out)

--- a/app/sheet_scoring/tasks.py
+++ b/app/sheet_scoring/tasks.py
@@ -1,0 +1,13 @@
+from celery import shared_task
+from .sheet_scoring import score_one_sheet
+from sefaria_llm_interface.scoring_io import (
+    SheetScoringInput
+)
+from dataclasses import asdict
+
+
+@shared_task(name='llm.score_sheet')
+def score_sheet_task(raw_input:dict) -> dict:
+    inp = SheetScoringInput(**raw_input)
+    out = score_one_sheet(inp)
+    return asdict(out)

--- a/app/sheet_scoring/text_utils.py
+++ b/app/sheet_scoring/text_utils.py
@@ -3,17 +3,17 @@ import html
 from typing import Dict, List, Tuple, Any
 
 TAG_RE = re.compile(r"<[^>]+>")
-TOKEN_RE = re.compile(r"\b\w+\b",re.UNICODE)
+TOKEN_RE = re.compile(r"\b\w+\b", re.UNICODE)
 
 
 def strip_html(raw: str) -> str:
     """Remove tags & entities, collapse whitespace."""
     if not raw:
         return ""
-    text = TAG_RE.sub("",raw)
+    text = TAG_RE.sub("", raw)
     text = html.unescape(text)
-    text = re.sub(r"\s+\n","\n",text)  # trim spaces before newlines
-    text = re.sub(r"[ \t]{2,}"," ",text)  # collapse runs of blanks
+    text = re.sub(r"\s+\n", "\n", text)  # trim spaces before newlines
+    text = re.sub(r"[ \t]{2,}", " ", text)  # collapse runs of blanks
     return text.strip()
 
 
@@ -39,13 +39,13 @@ def sheet_to_text_views(
     creativity_score   float – user_token_count / total_token_count
     """
 
-    quotes:     List[str] = []
-    no_quotes:  List[str] = []
-    with_quotes:List[str] = []
+    quotes: List[str] = []
+    no_quotes: List[str] = []
+    with_quotes: List[str] = []
 
     original_tokens = 0
-    quoted_tokens   = 0
-    has_original    = False
+    quoted_tokens = 0
+    has_original = False
 
     title = strip_html(sheet.get("title", "")).strip()
     if title:
@@ -75,7 +75,7 @@ def sheet_to_text_views(
                     with_quotes.append(txt)
 
         if "text" in blk:
-            ref   = blk.get("ref", "").strip()
+            ref = blk.get("ref", "").strip()
             canon = strip_html(blk["text"].get(default_lang, "")).strip()
 
             # show ref label in all views
@@ -106,11 +106,11 @@ def sheet_to_text_views(
                 with_quotes.append(txt)
 
     joiner = "\n\n"
-    quotes_only  = joiner.join(quotes)
-    commentary   = joiner.join(no_quotes)
-    full_sheet   = joiner.join(with_quotes)
+    quotes_only = joiner.join(quotes)
+    commentary = joiner.join(no_quotes)
+    full_sheet = joiner.join(with_quotes)
 
     total_tokens = original_tokens + quoted_tokens or 1  # avoid div‑by‑zero
-    creativity   = original_tokens / total_tokens
+    creativity = original_tokens / total_tokens
 
     return quotes_only, commentary, full_sheet, has_original, creativity

--- a/app/sheet_scoring/text_utils.py
+++ b/app/sheet_scoring/text_utils.py
@@ -1,0 +1,116 @@
+import re
+import html
+from typing import Dict, List, Tuple, Any
+
+TAG_RE = re.compile(r"<[^>]+>")
+TOKEN_RE = re.compile(r"\b\w+\b",re.UNICODE)
+
+
+def strip_html(raw: str) -> str:
+    """Remove tags & entities, collapse whitespace."""
+    if not raw:
+        return ""
+    text = TAG_RE.sub("",raw)
+    text = html.unescape(text)
+    text = re.sub(r"\s+\n","\n",text)  # trim spaces before newlines
+    text = re.sub(r"[ \t]{2,}"," ",text)  # collapse runs of blanks
+    return text.strip()
+
+
+def token_count(text: str) -> int:
+    """Approximate word tokens (both English & Hebrew)."""
+    return len(TOKEN_RE.findall(text))
+
+
+def sheet_to_text_views(
+    sheet: Dict[str, Any],
+    default_lang: str = "en",
+) -> Tuple[str, str, str, bool, float]:
+    """
+    Build three plain‑text snapshots of a Sefaria sheet **and** compute a
+    creativity score.
+
+    Returns
+    -------
+    quotes_only        str   – ref + canonical text blocks
+    no_quotes          str   – title & user commentary, refs only for quotes
+    with_quotes        str   – full sheet (title, commentary, *and* quotes)
+    has_original       bool  – True if any user commentary exists
+    creativity_score   float – user_token_count / total_token_count
+    """
+
+    quotes:     List[str] = []
+    no_quotes:  List[str] = []
+    with_quotes:List[str] = []
+
+    original_tokens = 0
+    quoted_tokens   = 0
+    has_original    = False
+
+    title = strip_html(sheet.get("title", "")).strip()
+    if title:
+        tok = token_count(title)
+        original_tokens += tok
+        no_quotes.append(title)
+        with_quotes.append(title)
+
+    for blk in sheet.get("sources", []):
+        # --- outsideText (single‑lang commentary)
+        if "outsideText" in blk:
+            txt = strip_html(blk["outsideText"]).strip()
+            if txt:
+                has_original = True
+                t = token_count(txt)
+                original_tokens += t
+                no_quotes.append(txt)
+                with_quotes.append(txt)
+
+        if "outsideBiText" in blk:
+            for lang in ("en", "he"):
+                txt = strip_html(blk["outsideBiText"].get(lang, "")).strip()
+                if txt:
+                    has_original = True
+                    original_tokens += token_count(txt)
+                    no_quotes.append(txt)
+                    with_quotes.append(txt)
+
+        if "text" in blk:
+            ref   = blk.get("ref", "").strip()
+            canon = strip_html(blk["text"].get(default_lang, "")).strip()
+
+            # show ref label in all views
+            if ref:
+                no_quotes.append(ref)
+                header = f"{ref}:"
+            else:
+                header = ""
+
+            if canon:
+                # quote tokens count toward quoted_tokens
+                qtok = token_count(canon)
+                quoted_tokens += qtok
+
+                # add to quotes‑only and with_quotes
+                if header:
+                    quotes.append(header)
+                    with_quotes.append(header)
+                quotes.append(canon)
+                with_quotes.append(canon)
+
+        if "comment" in blk:
+            txt = strip_html(blk["comment"]).strip()
+            if txt:
+                has_original = True
+                original_tokens += token_count(txt)
+                no_quotes.append(txt)
+                with_quotes.append(txt)
+
+    joiner = "\n\n"
+    quotes_only  = joiner.join(quotes)
+    commentary   = joiner.join(no_quotes)
+    full_sheet   = joiner.join(with_quotes)
+
+    total_tokens = original_tokens + quoted_tokens or 1  # avoid div‑by‑zero
+    creativity   = original_tokens / total_tokens
+
+    return quotes_only, commentary, full_sheet, has_original, creativity


### PR DESCRIPTION
…-based scoring

- Add SheetScorer class for scoring biblical reference discussion levels (0-4 scale), title interest, and creativity assessment with multi-language Hebrew/English support. Add resilient LLM processing with OpenAI function calling, recursive fallback handling, intelligent content chunking, and token management with smart truncation and LLM-based summarization for large sheets
- Add Celery integration with SheetScoringInput/SheetScoringOutput dataclasses in scoring_io module and score_sheet_task
- Register sheet_scoring package in Celery autodiscovery and add test script for validation
